### PR TITLE
array of CloudLayers should be empty for clear sky (NSC|NCD|CLR|SKC).

### DIFF
--- a/src/ChunkDecoder/CloudChunkDecoder.php
+++ b/src/ChunkDecoder/CloudChunkDecoder.php
@@ -41,7 +41,7 @@ class CloudChunkDecoder extends MetarChunkDecoder implements MetarChunkDecoderIn
 
             if ($found[2] != null) {
                 // handle the case where no clouds observed
-                // TODO what fields to map ?
+                $layers = array();
             } else {
                 // handle cloud layers and visibility
                 $layers = array();


### PR DESCRIPTION
Hi there,

I needed to know when there are no clouds. I think in this case getClouds() should return an empty array.
 