### PR TITLE
remove 'end of message' and all following characters.

### DIFF
--- a/src/ChunkDecoder/CloudChunkDecoder.php
+++ b/src/ChunkDecoder/CloudChunkDecoder.php
@@ -41,7 +41,7 @@ class CloudChunkDecoder extends MetarChunkDecoder implements MetarChunkDecoderIn
 
             if ($found[2] != null) {
                 // handle the case where no clouds observed
-                // TODO what fields to map ?
+                $layers = array();
             } else {
                 // handle cloud layers and visibility
                 $layers = array();

--- a/src/MetarDecoder.php
+++ b/src/MetarDecoder.php
@@ -87,8 +87,10 @@ class MetarDecoder
      */
     private function parseWithMode($raw_metar, $strict)
     {
+        // remove 'end of message' and following characters
+        $clean_metar = preg_replace('#=.*$#', '', $raw_metar);
         // prepare decoding inputs/outputs (upper case + trim + no more than one space)
-        $clean_metar = preg_replace("#[ ]{2,}#", ' ', trim(strtoupper($raw_metar))).' ';
+        $clean_metar = preg_replace("#[ ]{2,}#", ' ', trim(strtoupper($clean_metar))).' ';
         $remaining_metar = $clean_metar;
         $decoded_metar = new DecodedMetar($clean_metar);
         $with_cavok = false;

--- a/src/MetarDecoder.php
+++ b/src/MetarDecoder.php
@@ -87,10 +87,11 @@ class MetarDecoder
      */
     private function parseWithMode($raw_metar, $strict)
     {
-        // remove 'end of message' and following characters
-        $clean_metar = preg_replace('#=.*$#', '', $raw_metar);
-        // prepare decoding inputs/outputs (upper case + trim + no more than one space)
-        $clean_metar = preg_replace("#[ ]{2,}#", ' ', trim(strtoupper($clean_metar))).' ';
+        // prepare decoding inputs/outputs: (upper case, trim,
+        // remove 'end of message', no more than one space)
+        $clean_metar = trim(strtoupper($raw_metar));
+        $clean_metar = preg_replace('#=$#', '', $clean_metar);
+        $clean_metar = preg_replace("#[ ]{2,}#", ' ', $clean_metar) . ' ';
         $remaining_metar = $clean_metar;
         $decoded_metar = new DecodedMetar($clean_metar);
         $with_cavok = false;

--- a/tests/MetarDecoderTest.php
+++ b/tests/MetarDecoderTest.php
@@ -151,6 +151,16 @@ class MetarDecoderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test parsing of METAR with trailing end-of-message
+     */
+    public function testParseEOM()
+    {
+        $d = $this->decoder->parseStrict('METAR LFPB 190730Z AUTO 17005KT 6000 OVC024 02/00 Q1032=');
+        $this->assertTrue($d->isValid());
+        $this->assertEquals('METAR LFPB 190730Z AUTO 17005KT 6000 OVC024 02/00 Q1032', $d->getRawMetar());
+    }
+
+    /**
      * Test parsing of a METAR with CAVOK
      */
     public function testParseCAVOK()


### PR DESCRIPTION
METAR messages from DWD (German Meteorological Service) often include 'end of message' characters, e.g.

    METAR EDDB 041220Z 23014KT 9999 BKN022 08/06 Q1023 TEMPO 24015G25KT=

With this patch these will be ignored.